### PR TITLE
Pan 128: Site additional filtering in edit mode

### DIFF
--- a/src/app/common/components/header/header.component.html
+++ b/src/app/common/components/header/header.component.html
@@ -211,7 +211,7 @@
           class="adsh-adst"
           data-test="user-total-funds"
         >
-          {{ userDataState.adserverWallet.totalFunds | number:'1.2-2' | adsharesTokenValue }}
+          {{ userDataState.adserverWallet.totalFunds | adsharesTokenValue:2 }}
         </span>
         <span
           class="adsh-usd"

--- a/src/app/common/components/header/header.component.html
+++ b/src/app/common/components/header/header.component.html
@@ -211,7 +211,7 @@
           class="adsh-adst"
           data-test="user-total-funds"
         >
-          {{ userDataState.adserverWallet.totalFunds | number:'1.2-2' | adsharesTokenValue }}
+          <!--{{ userDataState.adserverWallet.totalFunds | number:'1.2-2' | adsharesTokenValue }}-->
         </span>
         <span
           class="adsh-usd"

--- a/src/app/common/components/header/header.component.html
+++ b/src/app/common/components/header/header.component.html
@@ -211,7 +211,7 @@
           class="adsh-adst"
           data-test="user-total-funds"
         >
-          <!--{{ userDataState.adserverWallet.totalFunds | number:'1.2-2' | adsharesTokenValue }}-->
+          {{ userDataState.adserverWallet.totalFunds | number:'1.2-2' | adsharesTokenValue }}
         </span>
         <span
           class="adsh-usd"

--- a/src/app/common/components/targeting/targeting.helpers.ts
+++ b/src/app/common/components/targeting/targeting.helpers.ts
@@ -160,7 +160,6 @@ export function parseTargetingOptionsToArray(targetingObject, targetingOptions):
   const requiresResult = [];
   const excludesResult = [];
   const targetingOptionTopKeys = targetingOptions.map(targeting => targeting.id);
-
   if (targetingObject) {
     generateTargetingKeysArray(targetingObject.requires, requiresResultKeys, targetingOptionTopKeys);
     generateTargetingKeysArray(targetingObject.excludes, excludesResultKeys, targetingOptionTopKeys);
@@ -223,7 +222,9 @@ function addTargetingOptionToResult(resultKey, result, targetingOptions) {
 
 function addCustomOptionToResult(optionKeys, results, targetingOptions) {
   optionKeys.forEach(optionKey => {
-    const addedResultIndex = results.findIndex(result => result.id === optionKey);
+    const addedResultIndex = !!results.length && results.findIndex(result => {
+
+      return result.id === optionKey});
 
     if (addedResultIndex === -1) {
       const parentKeyPathArray = optionKey.split('-');

--- a/src/app/models/app-state.model.ts
+++ b/src/app/models/app-state.model.ts
@@ -4,6 +4,7 @@ import { AdminSettings, BillingHistoryItem, NotificationItem, UserInfoStats } fr
 import { User } from './user.model';
 import { ChartFilterSettings } from './chart/chart-filter-settings.model';
 import { Notification } from 'models/notification.model';
+import {TargetingOption} from "models/targeting-option.model";
 
 
 interface AppState {
@@ -27,6 +28,7 @@ interface PublisherState {
   sitesTotals: SitesTotals;
   lastEditedSite: Site;
   languagesList: SiteLanguage[];
+  filteringCriteria: TargetingOption[];
 }
 
 interface SettingsState {

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
@@ -133,20 +133,15 @@
       row
       justify-between"
   >
-    <a
-      routerLink="../basic-information"
-      [queryParams]="{step: 1}"
-      data-test="publisher-edit-site-navigate-back"
-    >
-      <button
-        class="
+    <button
+      class="
           adsh-btn
           adsh-btn--white
           adsh-blue"
-      >
-        Back
-      </button>
-    </a>
+      role="link"
+      (click)="onStepBack()">
+      {{createSiteMode ? 'Back' : 'Back to Site Details'}}
+    </button>
 
     <div class="row">
       <button
@@ -162,7 +157,7 @@
         Save as Draft
       </button>
       <button
-        (click)="saveSite(false)"
+        (click)="onSubmit()"
         class="
           adsh-btn
           adsh-btn--blue"

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
@@ -150,6 +150,7 @@
 
     <div class="row">
       <button
+        *ngIf="createSiteMode"
         (click)="saveSite(true)"
         class="
           adsh-btn
@@ -161,13 +162,13 @@
         Save as Draft
       </button>
       <button
-        (click)="saveSite(false)"
+        (click)="onSubmit()"
         class="
           adsh-btn
           adsh-btn--blue"
         data-test="publisher-edit-site-save-and-continue"
       >
-        <span *ngIf="!changesSaved; else loading">Save & Continue</span>
+        <span *ngIf="!changesSaved; else loading">{{createSiteMode ? "Save & Continue" : "Update Site" }}</span>
         <ng-template #loading>
           <mat-spinner [diameter]="20" [strokeWidth]="2" color="accent"></mat-spinner>
         </ng-template>

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.html
@@ -162,7 +162,7 @@
         Save as Draft
       </button>
       <button
-        (click)="onSubmit()"
+        (click)="saveSite(false)"
         class="
           adsh-btn
           adsh-btn--blue"

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
@@ -104,8 +104,9 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
     const updateSubscription = this.publisherService.updateSiteFiltering(this.siteToSave.id, this.siteToSave)
       .subscribe(
         () => {
+          const siteId = this.site.id;
           this.store.dispatch(new publisherActions.ClearLastEditedSite());
-          this.router.navigate(['/publisher', 'site', this.site.id]);
+          this.router.navigate(['/publisher', 'site', siteId]);
         }
       );
     this.subscriptions.push(updateSubscription);
@@ -119,7 +120,6 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
     };
 
     this.changesSaved = true;
-
     this.store.dispatch(new publisherActions.SaveSiteFiltering(chosenTargeting));
 
     if (!isDraft) {
@@ -127,12 +127,10 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
         ['/publisher', 'create-site', 'create-ad-units'],
         {queryParams: {step: 3}}
       );
-
       return;
     }
-
     this.store.dispatch(new publisherActions.AddSiteToSitesSuccess(this.site));
-
+    this.store.dispatch(new publisherActions.ClearLastEditedSite());
   }
 
   getSiteFromStore() {

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
@@ -73,6 +73,16 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
     return this.createSiteMode ? this.saveSite(false) : this.updateSite();
   }
 
+  onStepBack(): void {
+    if (!this.createSiteMode) {
+      this.router.navigate(['/publisher', 'create-site', 'basic-information'],
+        {queryParams: {step: 1}})
+    } else {
+      this.store.dispatch(new publisherActions.ClearLastEditedSite({}));
+      this.router.navigate(['/publisher', 'site', this.site.id]);
+    }
+  }
+
   get siteToSave(): Site {
     return {
       ...this.site,
@@ -118,6 +128,7 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
     const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
       .first()
       .subscribe((lastEditedSite: Site) => {
+
         this.store.dispatch(new publisherActions.AddSiteToSitesSuccess(lastEditedSite));
         this.router.navigate(['/publisher', 'dashboard']);
       });

--- a/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
+++ b/src/app/publisher/edit-site/edit-site-additional-targeting/edit-site-additional-targeting.component.ts
@@ -13,7 +13,7 @@ import {PublisherService} from 'publisher/publisher.service';
 import {AssetHelpersService} from 'common/asset-helpers.service';
 import {Site} from 'models/site.model';
 import {TargetingSelectComponent} from 'common/components/targeting/targeting-select/targeting-select.component';
-import {parseTargetingOptionsToArray, prepareTargetingChoices} from "common/components/targeting/targeting.helpers";
+import {parseTargetingOptionsToArray} from "common/components/targeting/targeting.helpers";
 
 //TODO in PAN-25 -> replace rest of targeting variables with filtering ones
 
@@ -96,7 +96,7 @@ export class EditSiteAdditionalTargetingComponent extends HandleLeaveEditProcess
 
   }
 
-    saveSite(isDraft) {
+  saveSite(isDraft) {
     const chosenTargeting = {
       requires: this.addedItems,
       excludes: this.excludedItems

--- a/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
+++ b/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
@@ -55,6 +55,7 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
     const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
       .first()
       .subscribe((lastEditedSite: Site) => {
+        console.log('units last', lastEditedSite)
         const siteUrlFilled = this.assetHelpers.redirectIfNameNotFilled(lastEditedSite);
         if (!siteUrlFilled) {
           this.changesSaved = true;
@@ -149,6 +150,8 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
       });
       return;
     }
+
+
     this.adUnitsSubmitted = true;
     const adUnitsValid = this.adUnitForms.every((adForm) => adForm.valid);
 
@@ -163,6 +166,11 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
           status: form.get('status').value
         };
       });
+      const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
+        .first()
+        .subscribe((site: Site) => {
+          console.log('usits submit', site)
+        });
 
       this.store.dispatch(new publisherActions.SaveLastEditedSiteAdUnits(adUnitToSave));
       this.redirectAfterSave(isDraft);

--- a/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
+++ b/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
@@ -56,7 +56,6 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
       .first()
       .subscribe((lastEditedSite: Site) => {
         const siteUrlFilled = this.assetHelpers.redirectIfNameNotFilled(lastEditedSite);
-
         if (!siteUrlFilled) {
           this.changesSaved = true;
           return;
@@ -171,6 +170,7 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
   }
 
   redirectAfterSave(isDraft: boolean): void {
+
     if (!isDraft) {
       this.router.navigate(
         ['/publisher', this.createSiteMode ? 'create-site' : 'edit-site', 'summary'],
@@ -179,6 +179,7 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
 
       return;
     }
+
     const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
       .first()
       .subscribe((site: Site) => {

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
@@ -42,22 +42,19 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
   }
 
   ngOnInit() {
-
     this.createSiteMode = !!this.router.url.match('/create-site/');
 
     const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
       .subscribe((lastEditedSite: Site) => {
-        this.site = cloneDeep(lastEditedSite);
-        console.log('const site 2', this.site);
-
-        // this.assetHelpers.redirectIfNameNotFilled(site.lastEditedSite);
+        this.filteringOptions = cloneDeep(this.route.parent.snapshot.data.targetingOptions);
+        this.site = Object.assign({}, lastEditedSite);
       });
+
     this.subscriptions.push(lastSiteSubscription);
+    this.assetHelpers.redirectIfNameNotFilled(this.site);
 
-
-    this.filteringOptions = cloneDeep(this.route.parent.snapshot.data.targetingOptions);
-    this.site.filtering = parseTargetingOptionsToArray(this.site.filtering, this.filteringOptions);
   }
+
 
   ngOnDestroy() {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
@@ -44,6 +44,8 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
 
     this.store.select('state', 'publisher', 'lastEditedSite')
       .subscribe((site: Site) => {
+        console.log('last', site)
+
         this.assetHelpers.redirectIfNameNotFilled(site);
         this.site = site;
       });

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
@@ -15,7 +15,6 @@ import {HandleSubscription} from 'common/handle-subscription';
 import {TargetingOption} from 'models/targeting-option.model';
 import {cloneDeep} from 'common/utilities/helpers';
 import {ErrorResponseDialogComponent} from "common/dialog/error-response-dialog/error-response-dialog.component";
-import {parseTargetingOptionsToArray} from "common/components/targeting/targeting.helpers";
 import {Subscription} from "rxjs";
 
 @Component({
@@ -52,9 +51,7 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
 
     this.subscriptions.push(lastSiteSubscription);
     this.assetHelpers.redirectIfNameNotFilled(this.site);
-
   }
-
 
   ngOnDestroy() {
     this.subscriptions.forEach(subscription => subscription.unsubscribe());

--- a/src/app/publisher/publisher.service.ts
+++ b/src/app/publisher/publisher.service.ts
@@ -51,7 +51,6 @@ export class PublisherService {
   updateSiteFiltering(id: number, site: Site): Observable<Site> {
     if (site.filtering) {
       const targetingObject = parseTargetingForBackend(site.filtering);
-      console.log(targetingObject)
 
       Object.assign(site, {filtering: targetingObject});
     }

--- a/src/app/publisher/publisher.service.ts
+++ b/src/app/publisher/publisher.service.ts
@@ -33,6 +33,7 @@ export class PublisherService {
   saveSite(site: Site): Observable<Site> {
     if (site.filtering) {
       const targetingObject = parseTargetingForBackend(site.filtering);
+      console.log(targetingObject)
 
       Object.assign(site, {filtering: targetingObject});
     }
@@ -50,6 +51,7 @@ export class PublisherService {
   updateSiteFiltering(id: number, site: Site): Observable<Site> {
     if (site.filtering) {
       const targetingObject = parseTargetingForBackend(site.filtering);
+      console.log(targetingObject)
 
       Object.assign(site, {filtering: targetingObject});
     }

--- a/src/app/publisher/publisher.service.ts
+++ b/src/app/publisher/publisher.service.ts
@@ -33,8 +33,6 @@ export class PublisherService {
   saveSite(site: Site): Observable<Site> {
     if (site.filtering) {
       const targetingObject = parseTargetingForBackend(site.filtering);
-      console.log(targetingObject)
-
       Object.assign(site, {filtering: targetingObject});
     }
     return this.http.post<Site>(`${environment.apiUrl}/sites`, {site});

--- a/src/app/publisher/site-details/site-details.component.html
+++ b/src/app/publisher/site-details/site-details.component.html
@@ -161,7 +161,7 @@
         Site language:
         <span
           class="lowercase">
-          {{language.name}}
+          {{language && language.name}}
         </span>
       </p>
       <button

--- a/src/app/publisher/site-details/site-details.component.ts
+++ b/src/app/publisher/site-details/site-details.component.ts
@@ -63,10 +63,7 @@ export class SiteDetailsComponent extends HandleSubscription implements OnInit {
 
   ngOnInit() {
     this.site = this.route.snapshot.data.site;
-
-    this.getFiltering();
     this.getLanguages();
-
     const chartFilterSubscription = this.store.select('state', 'common', 'chartFilterSettings')
       .subscribe((chartFilterSettings: ChartFilterSettings) => {
         this.currentChartFilterSettings = chartFilterSettings;
@@ -74,6 +71,7 @@ export class SiteDetailsComponent extends HandleSubscription implements OnInit {
     this.subscriptions.push(chartFilterSubscription);
 
     this.getChartData(this.currentChartFilterSettings);
+    this.getFilteringFiltering();
   }
 
   deleteSite() {
@@ -117,6 +115,17 @@ export class SiteDetailsComponent extends HandleSubscription implements OnInit {
       });
   }
 
+  getFilteringFiltering() {
+    this.store.select('state', 'publisher', 'filteringCriteria')
+      .subscribe((filteringOptions) => {
+        this.filteringOptions = filteringOptions;
+        this.filtering = parseTargetingOptionsToArray(this.site.filtering, this.filteringOptions);
+        if (!filteringOptions.length) {
+          this.store.dispatch(new PublisherActions.GetFilteringCriteria());
+        }
+      });
+  }
+
   getChartData(chartFilterSettings) {
     this.barChartData.forEach(values => values[0].data = []);
 
@@ -154,16 +163,6 @@ export class SiteDetailsComponent extends HandleSubscription implements OnInit {
       ['/publisher', 'edit-site', 'create-ad-units'],
       {queryParams: {step: 3, summary: true}}
     );
-  }
-
-  getFiltering() {
-    const getSiteFilteringSubscription = this.publisherService.getFilteringCriteria()
-      .map((filteringOptions) => prepareTargetingChoices(filteringOptions))
-      .subscribe(filteringOptions => {
-        this.filteringOptions = filteringOptions;
-        this.filtering = parseTargetingOptionsToArray(this.site.filtering, filteringOptions);
-      });
-    this.subscriptions.push(getSiteFilteringSubscription);
   }
 
   onSiteStatusChange(status) {

--- a/src/app/store/publisher/publisher.actions.ts
+++ b/src/app/store/publisher/publisher.actions.ts
@@ -1,12 +1,15 @@
 import { Action } from '@ngrx/store';
 
 import { AdUnit, Site, SiteLanguage } from 'models/site.model';
-import { AssetTargeting } from 'models/targeting-option.model';
+import {AssetTargeting, TargetingOption} from 'models/targeting-option.model';
 import { TimespanFilter } from 'models/chart/chart-filter-settings.model';
 
 export const GET_LANGUAGES_LIST = 'Getting languages';
 export const GET_LANGUAGES_LIST_SUCCESS = 'Languages list loaded';
 export const GET_LANGUAGES_LIST_FAILURE = 'Languages loading failure';
+export const GET_FILTERING_CRITERIA = 'Getting filtering criteria';
+export const GET_FILTERING_CRITERIA_SUCCESS = 'Filtering criteria loaded';
+export const GET_FILTERING_CRITERIA_FAILURE = 'Filtering criteria loading failure';
 export const LOAD_SITES = 'Sites loaded';
 export const LOAD_SITES_SUCCESS = 'Sites loaded success';
 export const LOAD_SITES_TOTALS = 'Sites totals loaded';
@@ -50,7 +53,7 @@ export class LoadSitesTotalsSuccess implements Action {
 export class ClearLastEditedSite implements Action {
   readonly type: string = CLEAR_LAST_EDITED_SITE;
 
-  constructor(public payload: any) {
+  constructor(public payload?: any) {
   }
 }
 
@@ -116,11 +119,34 @@ export class GetLanguagesListFailure implements Action {
   constructor(public payload: any) {
   }
 }
+export class GetFilteringCriteria implements Action {
+  readonly type = GET_FILTERING_CRITERIA;
+
+  constructor(public payload?: any) {
+  }
+}
+
+export class GetFilteringCriteriaSuccess implements Action {
+  readonly type = GET_FILTERING_CRITERIA_SUCCESS;
+
+  constructor(public payload: TargetingOption[]) {
+  }
+}
+
+export class GetFilteringCriteriaFailure implements Action {
+  readonly type = GET_FILTERING_CRITERIA_FAILURE;
+
+  constructor(public payload?: any) {
+  }
+}
 
 export type actions =
   GetLanguagesList |
   GetLanguagesListSuccess |
   GetLanguagesListFailure |
+  GetFilteringCriteria |
+  GetFilteringCriteriaSuccess |
+  GetFilteringCriteriaFailure |
   LoadSites |
   LoadSitesSuccess |
   LoadSitesTotals |

--- a/src/app/store/publisher/publisher.effects.ts
+++ b/src/app/store/publisher/publisher.effects.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@angular/core';
-import { Actions, Effect, toPayload } from '@ngrx/effects';
+import {Injectable} from '@angular/core';
+import {Actions, Effect, toPayload} from '@ngrx/effects';
 import 'rxjs/add/operator/switchMap';
 
-import { PublisherService } from 'publisher/publisher.service';
+import {PublisherService} from 'publisher/publisher.service';
 import * as publisherActions from './publisher.actions';
+import {prepareTargetingChoices} from "common/components/targeting/targeting.helpers";
 
 @Injectable()
 export class PublisherEffects {
@@ -40,4 +41,12 @@ export class PublisherEffects {
     .map(toPayload)
     .switchMap(() => this.service.getLanguagesList())
     .map((list) => new publisherActions.GetLanguagesListSuccess(list));
+
+  @Effect()
+  getFilteringCriteria = this.actions$
+    .ofType(publisherActions.GET_FILTERING_CRITERIA)
+    .map(toPayload)
+    .switchMap(() => this.service.getFilteringCriteria())
+    .map((filteringOptions) => prepareTargetingChoices(filteringOptions))
+    .map((criteria) => new publisherActions.GetFilteringCriteriaSuccess(criteria));
 }

--- a/src/app/store/publisher/publisher.reducers.ts
+++ b/src/app/store/publisher/publisher.reducers.ts
@@ -46,6 +46,14 @@ export function publisherReducers(state = initialState, action: PublisherActions
         }
       };
     case PublisherActions.SAVE_LAST_EDITED_SITE_AD_UNITS:
+      const x =  {
+        ...state,
+        lastEditedSite: {
+          ...state.lastEditedSite,
+          adUnits: action.payload
+        }};
+        console.log('reducer', x.lastEditedSite)
+        console.log('reducer', x.lastEditedSite.adUnits)
       return {
         ...state,
         lastEditedSite: {

--- a/src/app/store/publisher/publisher.reducers.ts
+++ b/src/app/store/publisher/publisher.reducers.ts
@@ -52,8 +52,6 @@ export function publisherReducers(state = initialState, action: PublisherActions
           ...state.lastEditedSite,
           adUnits: action.payload
         }};
-        console.log('reducer', x.lastEditedSite)
-        console.log('reducer', x.lastEditedSite.adUnits)
       return {
         ...state,
         lastEditedSite: {

--- a/src/app/store/publisher/publisher.reducers.ts
+++ b/src/app/store/publisher/publisher.reducers.ts
@@ -1,12 +1,13 @@
 import * as PublisherActions from './publisher.actions';
-import { siteInitialState, sitesTotalsInitialState } from 'models/initial-state/site';
-import { PublisherState } from 'models/app-state.model';
+import {siteInitialState, sitesTotalsInitialState} from 'models/initial-state/site';
+import {PublisherState} from 'models/app-state.model';
 
 const initialState: PublisherState = {
   sites: [],
   sitesTotals: sitesTotalsInitialState,
   lastEditedSite: siteInitialState,
   languagesList: [],
+  filteringCriteria: [],
 };
 
 export function publisherReducers(state = initialState, action: PublisherActions.actions) {
@@ -24,27 +25,33 @@ export function publisherReducers(state = initialState, action: PublisherActions
     case PublisherActions.SAVE_LAST_EDITED_SITE:
       return {
         ...state,
-        lastEditedSite: Object.assign({}, state.lastEditedSite, action.payload)
+        lastEditedSite: {...state.lastEditedSite, ...action.payload}
       };
     case PublisherActions.CLEAR_LAST_EDITED_SITE:
       return {
         ...state,
-        lastEditedSite: Object.assign({}, siteInitialState)
+        lastEditedSite: {...siteInitialState}
       };
     case PublisherActions.SET_LAST_EDITED_SITE:
       return {
         ...state,
-        lastEditedSite: Object.assign({}, action.payload)
+        lastEditedSite: {...action.payload}
       };
     case PublisherActions.SAVE_LAST_EDITED_SITE_FILTERING:
       return {
         ...state,
-        lastEditedSite: Object.assign({}, state.lastEditedSite, {filtering: action.payload})
+        lastEditedSite: {
+          ...state.lastEditedSite,
+          filtering: action.payload
+        }
       };
     case PublisherActions.SAVE_LAST_EDITED_SITE_AD_UNITS:
       return {
         ...state,
-        lastEditedSite: Object.assign({}, state.lastEditedSite, {adUnits: action.payload})
+        lastEditedSite: {
+          ...state.lastEditedSite,
+          adUnits: action.payload
+        }
       };
     case PublisherActions.ADD_SITE_TO_SITES_SUCCESS:
       return {
@@ -56,6 +63,12 @@ export function publisherReducers(state = initialState, action: PublisherActions
       return {
         ...state,
         languagesList: [...action.payload]
+      };
+
+    case PublisherActions.GET_FILTERING_CRITERIA_SUCCESS:
+      return {
+        ...state,
+        filteringCriteria: [...action.payload]
       };
     default:
       return state;


### PR DESCRIPTION
In this PR:
- Addition of object in store for keeping filtering criteria to avoid unnecessary requests. 
- Functions for saving the new site and updating the existing one were separated 
- All changes inside summary component are related to missing filtering data issue