### PR TITLE
PAN 96: Size selecting

### DIFF
--- a/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
+++ b/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
@@ -134,6 +134,9 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
           : parseInt(adSizesEnum[filterValue]) === adUnitSize.size
         )
     );
+
+    this.filteredAdUnitSizes[adUnitIndex].find(adUnit =>
+      adUnit.label === this.adUnitForms[adUnitIndex].get('size').value.label).selected = true;
   }
 
   selectAdUnit(adUnit: AdUnitSize, adUnitIndex: number): void {
@@ -165,7 +168,6 @@ export class EditSiteCreateAdUnitsComponent extends HandleLeaveEditProcess imple
         {queryParams: {step: 2}})
     }
   }
-
 
   updateAdUnits(): void {
     const adUnitsValid = this.adUnitForms.every((adForm) => adForm.valid);


### PR DESCRIPTION
In this PR:
When ad unit size is selected there is no way to unselect it. The user can only select another size instead or delete the ad unit. When a user selects the size and then filter sizes and selected size is not visible, it is still selected until the user selects another one by clicking on it. 