### PR TITLE
PAN-225: Show warning when campaign cannot be automatically activated

### DIFF
--- a/src/app/advertiser/advertiser-routing.module.ts
+++ b/src/app/advertiser/advertiser-routing.module.ts
@@ -81,7 +81,7 @@ const advertiserRoutes: Routes = [
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(advertiserRoutes)
+    RouterModule.forChild(advertiserRoutes)
   ],
   exports: [
     RouterModule

--- a/src/app/advertiser/campaign-list/campaign-list-item/campaign-list-item.component.html
+++ b/src/app/advertiser/campaign-list/campaign-list-item/campaign-list-item.component.html
@@ -11,20 +11,23 @@
       class="
         row
         align-center
+        justify-between
         dwmth-copy"
     >
       <div
         class="
-          col-xs-1
           row
+          dwmth-campaign-list__status-cell
           align-center"
       >
         <div class="dwmth-status"
              [attr.data-status]="currentCampaignStatus"
+             (click)="statusSelect.open()"
         >
           {{ currentCampaignStatus }}
           <div class="status-wrapper__list-item">
-            <mat-select [value]=" "
+            <mat-select #statusSelect
+                        [value]=" "
                         data-test="advertiser-campaign-status-select"
             >
 
@@ -44,7 +47,7 @@
       </div>
       <div
         class="
-          col-xs-4
+          col-xs-3
           row
           clickable-row
           align-center"

--- a/src/app/advertiser/campaign-list/campaign-list-item/campaign-list-item.component.scss
+++ b/src/app/advertiser/campaign-list/campaign-list-item/campaign-list-item.component.scss
@@ -1,5 +1,11 @@
 @import '../../../../styles.scss';
 
-.dwmth-campaign-list__item-campaign-details {
-  height: 33px;
+.dwmth-campaign-list{
+ &__item-campaign-details {
+   height: 33px;
+ }
+
+  &__status-cell{
+    width: 150px;
+  }
 }

--- a/src/app/advertiser/campaign-list/campaign-list.component.html
+++ b/src/app/advertiser/campaign-list/campaign-list.component.html
@@ -21,19 +21,20 @@
         class="dwmth-box
                dwmth-posters-list__item
               row
+              justify-between
               align-center
               dwmth-copy
               dwmth-copy--semi">
 
       <td
         class="
-                col-xs-1
+                dwmth-posters-list__status-totals-column
                 row
                 align-center"
       ></td>
       <td
         class="
-                col-xs-5
+                col-xs-3
                 row
                 align-center"
       >
@@ -45,6 +46,12 @@
                 Total - All Campaigns
               </span>
       </td>
+      <td
+        class="
+                col-xs-1
+                row
+                align-center"
+      ></td>
       <td
         class="
                 col-xs-1
@@ -85,6 +92,12 @@
       >
         <span>{{ campaignsTotals.cost | adsharesTokenValue:2 }}</span>
       </td>
+      <td
+        class="
+                col-xs-1
+                row
+                align-center"
+      ></td>
     </tr>
     </tbody>
   </table>

--- a/src/app/advertiser/campaign-list/campaign-list.component.scss
+++ b/src/app/advertiser/campaign-list/campaign-list.component.scss
@@ -13,4 +13,7 @@
       padding: 10px;
     }
   }
+  &__status-totals-column {
+    width: 150px;
+  }
 }

--- a/src/app/advertiser/edit-campaign/edit-campaign-additional-targeting/edit-campaign-additional-targeting.component.ts
+++ b/src/app/advertiser/edit-campaign/edit-campaign-additional-targeting/edit-campaign-additional-targeting.component.ts
@@ -1,30 +1,33 @@
-import {Component, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Router} from '@angular/router';
-import {Subscription} from 'rxjs/Subscription';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import 'rxjs/add/operator/first';
 
-import {Store} from '@ngrx/store';
-import * as advertiserActions from 'store/advertiser/advertiser.actions';
-import {AppState} from 'models/app-state.model';
-import {TargetingOption, TargetingOptionValue} from 'models/targeting-option.model';
-import {cloneDeep} from 'common/utilities/helpers';
-import {AdvertiserService} from 'advertiser/advertiser.service';
-import {AssetHelpersService} from 'common/asset-helpers.service';
-import {Campaign} from 'models/campaign.model';
-import {TargetingSelectComponent} from 'common/components/targeting/targeting-select/targeting-select.component';
+import { Store } from '@ngrx/store';
+import {
+  SaveCampaignTargeting,
+  ClearLastEditedCampaign,
+  UpdateCampaign,
+  AddCampaignToCampaigns
+} from 'store/advertiser/advertiser.actions';
+import { AppState } from 'models/app-state.model';
+import { TargetingOption, TargetingOptionValue } from 'models/targeting-option.model';
+import { cloneDeep } from 'common/utilities/helpers';
+import { AdvertiserService } from 'advertiser/advertiser.service';
+import { AssetHelpersService } from 'common/asset-helpers.service';
+import { Campaign } from 'models/campaign.model';
+import { TargetingSelectComponent } from 'common/components/targeting/targeting-select/targeting-select.component';
+import { HandleSubscription } from "common/handle-subscription";
 
 @Component({
   selector: 'app-edit-campaign-additional-targeting',
   templateUrl: './edit-campaign-additional-targeting.component.html',
   styleUrls: ['./edit-campaign-additional-targeting.component.scss']
 })
-export class EditCampaignAdditionalTargetingComponent implements OnInit, OnDestroy {
+export class EditCampaignAdditionalTargetingComponent extends HandleSubscription implements OnInit {
   @ViewChild(TargetingSelectComponent) targetingSelectComponent: TargetingSelectComponent;
   excludePanelOpenState: boolean;
   requirePanelOpenState: boolean;
   goesToSummary: boolean;
-
-  subscriptions: Subscription[] = [];
   campaign: Campaign;
   targetingOptionsToAdd: TargetingOption[];
   targetingOptionsToExclude: TargetingOption[];
@@ -40,6 +43,7 @@ export class EditCampaignAdditionalTargetingComponent implements OnInit, OnDestr
     private advertiserService: AdvertiserService,
     private assetHelpers: AssetHelpersService
   ) {
+    super();
   }
 
   ngOnInit() {
@@ -50,10 +54,6 @@ export class EditCampaignAdditionalTargetingComponent implements OnInit, OnDestr
     this.getTargetingFromStore();
     const subscription = this.advertiserService.cleanEditedCampaignOnRouteChange(!this.createCampaignMode);
     subscription && this.subscriptions.push(subscription);
-  }
-
-  ngOnDestroy() {
-    this.subscriptions.forEach(subscription => subscription.unsubscribe());
   }
 
   updateAddedItems(items) {
@@ -70,7 +70,7 @@ export class EditCampaignAdditionalTargetingComponent implements OnInit, OnDestr
         ['/advertiser', 'create-campaign', 'basic-information'],
         {queryParams: {step: 1}});
     } else {
-      this.store.dispatch(new advertiserActions.ClearLastEditedCampaign());
+      this.store.dispatch(new ClearLastEditedCampaign());
       this.router.navigate(['/advertiser', 'campaign', this.campaign.id]);
     }
   }
@@ -86,37 +86,33 @@ export class EditCampaignAdditionalTargetingComponent implements OnInit, OnDestr
       excludes: this.excludedItems
     };
     const updatedCampaign = {...this.campaign, targetingArray: {...targeting}};
-    this.store.dispatch(new advertiserActions.UpdateCampaign(updatedCampaign));
+    this.store.dispatch(new UpdateCampaign(updatedCampaign));
   }
 
-  saveCampaignTargeting(isDraft) {
+  saveCampaignTargeting(isDraft): void {
     const chosenTargeting = {
       requires: this.addedItems,
       excludes: this.excludedItems
     };
 
     this.changesSaved = true;
-    this.store.dispatch(new advertiserActions.SaveCampaignTargeting(chosenTargeting));
 
     if (!isDraft) {
       const editCampaignStep = this.goesToSummary ? 'summary' : 'create-ad';
       const param = this.goesToSummary ? 4 : 3;
-
+      this.store.dispatch(new SaveCampaignTargeting(chosenTargeting));
       this.router.navigate(
         ['/advertiser', 'create-campaign', editCampaignStep],
         {queryParams: {step: param}}
       );
-
       return;
+    } else {
+      this.campaign = {
+        ...this.campaign,
+        targetingArray: chosenTargeting
+      };
+      this.store.dispatch(new AddCampaignToCampaigns(this.campaign));
     }
-
-    const lastCampaignSubscription = this.store.select('state', 'advertiser', 'lastEditedCampaign')
-      .first()
-      .subscribe((campaign: Campaign) => {
-        this.store.dispatch(new advertiserActions.AddCampaignToCampaigns(campaign));
-        this.router.navigate(['/advertiser', 'dashboard']);
-      });
-    this.subscriptions.push(lastCampaignSubscription);
   }
 
   getTargetingFromStore() {

--- a/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.html
+++ b/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.html
@@ -159,11 +159,11 @@
             class="
             dwmth-copy--small
             label"
-        >
-          Date of Start
-        </p>
-        <div
-          class="
+          >
+            Date of Start
+          </p>
+          <div
+            class="
             row
             align-center"
           >
@@ -414,30 +414,26 @@
     </a>
 
     <div class="row">
-      <a>
-        <button
-          class="
+      <button
+        class="
             dwmth-btn
             dwmth-btn--white
             dwmth-blue
             save-as-draft"
-          (click)="saveCampaign(true)"
-          data-test="advertiser-edit-campaign-save-as-draft"
-        >
-          Save as Draft
-        </button>
-      </a>
-      <a>
-        <button
-          class="
+        (click)="saveCampaign(true)"
+        data-test="advertiser-edit-campaign-save-as-draft"
+      >
+        Save as Draft
+      </button>
+      <button
+        class="
             dwmth-btn
             dwmth-btn--blue"
-          (click)="saveCampaign(false)"
-          data-test="advertiser-edit-campaign-start-campaign"
-        >
-          Start Campaign
-        </button>
-      </a>
+        (click)="saveCampaign(false)"
+        data-test="advertiser-edit-campaign-start-campaign"
+      >
+        Start Campaign
+      </button>
     </div>
   </div>
 </section>

--- a/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.ts
+++ b/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.ts
@@ -9,7 +9,7 @@ import { campaignStatusesEnum } from 'models/enum/campaign.enum';
 import { AdvertiserService } from 'advertiser/advertiser.service';
 import { AssetHelpersService } from 'common/asset-helpers.service';
 import { adStatusesEnum } from 'models/enum/ad.enum';
-import {AddCampaignToCampaigns} from 'store/advertiser/advertiser.actions';
+import { AddCampaignToCampaigns } from 'store/advertiser/advertiser.actions';
 import { HandleSubscription } from 'common/handle-subscription';
 import { TargetingOption } from 'models/targeting-option.model';
 import { cloneDeep } from 'common/utilities/helpers';

--- a/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.ts
+++ b/src/app/advertiser/edit-campaign/edit-campaign-summary/edit-campaign-summary.component.ts
@@ -1,20 +1,18 @@
-import {Component, OnInit} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {ActivatedRoute, Router} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { ActivatedRoute, Router } from '@angular/router';
 import 'rxjs/add/operator/first';
 
-import {AppState} from 'models/app-state.model';
-import {Campaign} from 'models/campaign.model';
-import {campaignStatusesEnum} from 'models/enum/campaign.enum';
-import {AdvertiserService} from 'advertiser/advertiser.service';
-import {AssetHelpersService} from 'common/asset-helpers.service';
-import {adStatusesEnum} from 'models/enum/ad.enum';
-import * as advertiserActions from 'store/advertiser/advertiser.actions';
-import {HandleSubscription} from 'common/handle-subscription';
-import {TargetingOption} from 'models/targeting-option.model';
-import {cloneDeep} from 'common/utilities/helpers';
-import {ErrorResponseDialogComponent} from "common/dialog/error-response-dialog/error-response-dialog.component";
-import {MatDialog} from "@angular/material";
+import { AppState } from 'models/app-state.model';
+import { Campaign } from 'models/campaign.model';
+import { campaignStatusesEnum } from 'models/enum/campaign.enum';
+import { AdvertiserService } from 'advertiser/advertiser.service';
+import { AssetHelpersService } from 'common/asset-helpers.service';
+import { adStatusesEnum } from 'models/enum/ad.enum';
+import {AddCampaignToCampaigns} from 'store/advertiser/advertiser.actions';
+import { HandleSubscription } from 'common/handle-subscription';
+import { TargetingOption } from 'models/targeting-option.model';
+import { cloneDeep } from 'common/utilities/helpers';
 
 @Component({
   selector: 'app-edit-campaign-summary',
@@ -35,13 +33,13 @@ export class EditCampaignSummaryComponent extends HandleSubscription implements 
     private assetHelpers: AssetHelpersService,
     private router: Router,
     private route: ActivatedRoute,
-    private dialog: MatDialog
   ) {
     super();
   }
 
   ngOnInit(): void {
     const lastCampaignSubscription = this.store.select('state', 'advertiser', 'lastEditedCampaign')
+      .first()
       .subscribe((campaign: Campaign) => {
         this.assetHelpers.redirectIfNameNotFilled(campaign);
         this.campaign = campaign;
@@ -57,39 +55,7 @@ export class EditCampaignSummaryComponent extends HandleSubscription implements 
       this.campaign.basicInformation.status = campaignStatusesEnum.ACTIVE;
       this.campaign.ads.forEach((ad) => ad.status = adStatusesEnum.ACTIVE);
     }
-
-    if (this.isEditMode()) {
-      this.editCampaign();
-    } else {
-      this.createNewCampaign();
-    }
-  }
-
-  private isEditMode(): boolean {
-    return this.campaign.id && this.campaign.id !== 0;
-  }
-
-  private editCampaign(): void {
-    this.store.dispatch(new advertiserActions.UpdateCampaign(this.campaign));
-  }
-
-  private createNewCampaign(): void {
-    this.advertiserService.saveCampaign(this.campaign).subscribe(
-      () => {
-        this.store.dispatch(new advertiserActions.AddCampaignToCampaignsSuccess(this.campaign));
-        this.store.dispatch(new advertiserActions.ClearLastEditedCampaign({}));
-        this.router.navigate(['/advertiser', 'dashboard']);
-      },
-
-      (err) => {
-        this.dialog.open(ErrorResponseDialogComponent, {
-          data: {
-            title: 'Ups! Something went wrong...',
-            message: `We weren\'t able to add a new campaign due to this error:  ${err}. Please try again later.`,
-          }
-        });
-      }
-    );
+    this.store.dispatch(new AddCampaignToCampaigns(this.campaign));
   }
 
   toggleTooltip(state, adIndex) {

--- a/src/app/auth/auth.component.scss
+++ b/src/app/auth/auth.component.scss
@@ -107,7 +107,7 @@
 }
 
 .application-version {
-  font-family: "AvenirNext-Regular", sans-serif;
+  font-family: "Lato-Regular", sans-serif;
   color: #99a3ae;
   font-size: 14px;
   float: right;

--- a/src/app/common/asset-helpers.service.ts
+++ b/src/app/common/asset-helpers.service.ts
@@ -16,11 +16,9 @@ export class AssetHelpersService {
         (asset['site'] && this.isSite(asset['site'])) ? asset['site']['name'] : asset['basicInformation']['name']
       );
     const fieldFilled = obligatoryField !== '';
-
     if (!fieldFilled) {
       const moduleDir = this.isSite(asset) ? 'publisher' : 'advertiser';
       const assetDir = this.isSite(asset) ? 'create-site' : 'create-campaign';
-
       this.router.navigate(
         [moduleDir, assetDir, 'basic-information'],
         {queryParams: {step: 1}}

--- a/src/app/common/components/chart/chart-settings.ts
+++ b/src/app/common/components/chart/chart-settings.ts
@@ -103,7 +103,7 @@ const chartOptions: ChartOptions = {
         left: position.left + 15 + tooltipModel.caretX + 'px',
         top: position.top + window.pageYOffset + tooltipModel.caretY + 'px',
         textAlign: 'left',
-        fontFamily: 'AvenirNext-Regular',
+        fontFamily: 'Lato-Regular',
         fontSize: 13 + 'px',
         color: '#FFFFFF',
         padding: '7px 10px',

--- a/src/app/common/components/header/header.component.scss
+++ b/src/app/common/components/header/header.component.scss
@@ -32,6 +32,7 @@
     text-transform: uppercase;
     color: pal(red, dark);
     font-size: 14px;
+    line-height: 1;
   }
 }
 

--- a/src/app/common/components/table-navigation/table-navigation.component.scss
+++ b/src/app/common/components/table-navigation/table-navigation.component.scss
@@ -6,3 +6,7 @@
     margin: 0;
   }
 }
+
+.status-cell-width {
+  width: 150px;
+}

--- a/src/app/common/components/table-navigation/table-navigation.component.ts
+++ b/src/app/common/components/table-navigation/table-navigation.component.ts
@@ -25,8 +25,8 @@ export class TableNavigationComponent implements OnInit {
   ];
 
   campaignListNavigationItems = [
-    {title: 'Status', columnWidth: 'col-xs-1', keys: ['basicInformation', 'status'], sortAsc: true},
-    {title: 'Campaign Title', columnWidth: 'col-xs-4', keys: ['basicInformation', 'name'], sortAsc: true},
+    {title: 'Status', columnWidth: 'status-cell-width', keys: ['basicInformation', 'status'], sortAsc: true},
+    {title: 'Campaign Title', columnWidth: 'col-xs-3', keys: ['basicInformation', 'name'], sortAsc: true},
     {title: 'Budget', columnWidth: 'col-xs-1', keys: ['basicInformation', 'budget'], sortAsc: true},
     {title: 'Clicks', columnWidth: 'col-xs-1', keys: ['clicks'], sortAsc: true},
     {title: 'Views', columnWidth: 'col-xs-1', keys: ['impressions'], sortAsc: true},

--- a/src/app/publisher/dashboard/dashboard.component.ts
+++ b/src/app/publisher/dashboard/dashboard.component.ts
@@ -7,12 +7,10 @@ import {ChartComponent} from 'common/components/chart/chart.component';
 import {SiteListComponent} from 'publisher/site-list/site-list.component';
 import {HandleSubscription} from 'common/handle-subscription';
 import {Site, SitesTotals} from 'models/site.model';
-import {chartSeriesEnum} from 'models/enum/chart.enum';
 import {ChartFilterSettings} from 'models/chart/chart-filter-settings.model';
 import {ChartData} from 'models/chart/chart-data.model';
-import {ChartLabels} from 'models/chart/chart-labels.model';
 import {AppState} from 'models/app-state.model';
-import {createInitialArray, enumToArray} from 'common/utilities/helpers';
+import {createInitialArray} from 'common/utilities/helpers';
 
 import * as publisherActions from 'store/publisher/publisher.actions';
 
@@ -50,7 +48,6 @@ export class DashboardComponent extends HandleSubscription implements OnInit {
         this.currentChartFilterSettings = chartFilterSettings;
       });
     this.subscriptions.push(chartFilterSubscription);
-
     this.loadSites(this.currentChartFilterSettings.currentFrom, this.currentChartFilterSettings.currentTo);
     this.getChartData(this.currentChartFilterSettings);
     this.userHasConfirmedEmail = this.store.select('state', 'user', 'data', 'isEmailConfirmed');
@@ -85,6 +82,7 @@ export class DashboardComponent extends HandleSubscription implements OnInit {
 
     const sitesSubscription = this.store.select('state', 'publisher', 'sites')
       .subscribe((sites: Site[]) => this.sites = sites);
+
     const sitesTotalsSubscription = this.store.select('state', 'publisher', 'sitesTotals')
       .subscribe((sitesTotals: SitesTotals) => this.sitesTotals = sitesTotals);
 

--- a/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
+++ b/src/app/publisher/edit-site/edit-site-create-ad-units/edit-site-create-ad-units.component.ts
@@ -15,6 +15,7 @@ import * as publisherActions from 'store/publisher/publisher.actions';
 import {ErrorResponseDialogComponent} from "common/dialog/error-response-dialog/error-response-dialog.component";
 import {MatDialog} from "@angular/material";
 import {HandleSubscription} from "common/handle-subscription";
+import { siteStatusEnum } from "models/enum/site.enum";
 
 @Component({
   selector: 'app-edit-site-create-poster-units',
@@ -210,12 +211,15 @@ export class EditSiteCreateAdUnitsComponent extends HandleSubscription implement
   redirectAfterSave(isDraft: boolean): void {
     this.changesSaved = false;
     if (isDraft) {
-      this.publisherService.saveAsDraft(this.site);
+      this.site = {
+        ...this.site,
+        status: siteStatusEnum.DRAFT
+      };
+      this.store.dispatch(new publisherActions.AddSiteToSites(this.site));
       return;
     }
-
     this.router.navigate(
-      ['/publisher', this.createSiteMode ? 'create-site' : 'edit-site', 'summary'],
+      ['/publisher', 'create-site', 'summary'],
       {queryParams: {step: 4}}
     );
   }

--- a/src/app/publisher/edit-site/edit-site-navigation/edit-site-navigation.component.ts
+++ b/src/app/publisher/edit-site/edit-site-navigation/edit-site-navigation.component.ts
@@ -1,13 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/Subscription';
+import { HandleSubscription } from "common/handle-subscription";
 
 @Component({
   selector: 'app-edit-site-navigation',
   templateUrl: './edit-site-navigation.component.html',
   styleUrls: ['./edit-site-navigation.component.scss'],
 })
-export class EditSiteNavigationComponent implements OnInit {
+export class EditSiteNavigationComponent extends HandleSubscription implements OnInit {
   steps = [
     {id: 1, name: 'Basic Information'},
     {id: 2, name: 'Filtering'},
@@ -16,14 +16,15 @@ export class EditSiteNavigationComponent implements OnInit {
   ];
 
   currentStep: number;
-  subscription: Subscription;
 
   constructor(private route: ActivatedRoute) {
+    super();
   }
 
   ngOnInit() {
-    this.subscription = this.route.queryParams.subscribe(params => {
+    const subscription = this.route.queryParams.subscribe(params => {
       this.currentStep = parseInt(params.step);
     });
+    this.subscriptions.push(subscription);
   }
 }

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.html
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.html
@@ -283,7 +283,6 @@
       justify-between"
   >
     <a
-      *ngIf="this.createSiteMode"
       routerLink="../create-ad-units"
       [queryParams]="{step: 3}"
       data-test="publisher-edit-site-navigate-back"
@@ -298,20 +297,9 @@
       </button>
     </a>
 
-    <button
-      *ngIf="!this.createSiteMode"
-      class="
-          dwmth-btn
-          dwmth-btn--white
-          dwmth-blue"
-      (click)="navigateToSiteDetails()"
-    >
-      Back
-    </button>
 
     <div class="row">
       <button
-        *ngIf="createSiteMode"
         class="
             dwmth-btn
             dwmth-btn--white
@@ -324,7 +312,6 @@
         Save as Draft
       </button>
       <button
-        *ngIf="createSiteMode"
         [disabled]="canSubmit"
         class="
             dwmth-btn
@@ -334,18 +321,6 @@
         data-test="publisher-edit-site-start-campaign"
       >
         Publish site
-      </button>
-      <button
-        *ngIf="!createSiteMode"
-        [disabled]="canSubmit"
-        class="
-            dwmth-btn
-            dwmth-btn--blue"
-        (click)="updateSite()"
-        type="button"
-        data-test="publisher-edit-site-start-campaign"
-      >
-        Update site
       </button>
     </div>
   </div>

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
@@ -1,20 +1,17 @@
-import {Component, OnInit} from '@angular/core';
-import {Store} from '@ngrx/store';
-import {ActivatedRoute, Router} from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { ActivatedRoute, Router } from '@angular/router';
 import 'rxjs/add/operator/first';
-import {MatDialog} from "@angular/material";
 
-import {AppState} from 'models/app-state.model';
-import {Site} from 'models/site.model';
-import {siteStatusEnum} from 'models/enum/site.enum';
-import {PublisherService} from 'publisher/publisher.service';
-import {AssetHelpersService} from 'common/asset-helpers.service';
-import * as publisherActions from 'store/publisher/publisher.actions';
-import {HandleSubscription} from 'common/handle-subscription';
-import {TargetingOption} from 'models/targeting-option.model';
-import {cloneDeep} from 'common/utilities/helpers';
-import {ErrorResponseDialogComponent} from "common/dialog/error-response-dialog/error-response-dialog.component";
-import { adSizesEnum } from "models/enum/ad.enum";
+import { AppState } from 'models/app-state.model';
+import { Site } from 'models/site.model';
+import { siteStatusEnum } from 'models/enum/site.enum';
+import { PublisherService } from 'publisher/publisher.service';
+import { AssetHelpersService } from 'common/asset-helpers.service';
+import {AddSiteToSites} from 'store/publisher/publisher.actions';
+import { HandleSubscription } from 'common/handle-subscription';
+import { TargetingOption } from 'models/targeting-option.model';
+import { cloneDeep } from 'common/utilities/helpers';
 
 @Component({
   selector: 'app-edit-site-summary',
@@ -24,7 +21,6 @@ import { adSizesEnum } from "models/enum/ad.enum";
 export class EditSiteSummaryComponent extends HandleSubscription implements OnInit {
   site: Site;
   filteringOptions: TargetingOption[];
-  createSiteMode: boolean;
   canSubmit: boolean;
 
   constructor(
@@ -33,19 +29,16 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
     private assetHelpers: AssetHelpersService,
     private router: Router,
     private route: ActivatedRoute,
-    private dialog: MatDialog
   ) {
     super();
   }
 
   ngOnInit() {
-
-    this.createSiteMode = !!this.router.url.match('/create-site/');
-
     const lastSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
+      .first()
       .subscribe((lastEditedSite: Site) => {
         this.filteringOptions = cloneDeep(this.route.parent.snapshot.data.filteringOptions);
-        this.site = Object.assign({}, lastEditedSite);
+        this.site =  lastEditedSite;
       });
 
     this.subscriptions.push(lastSiteSubscription);
@@ -54,42 +47,9 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
 
   saveSite(isDraft): void {
     this.canSubmit = false;
-
     if (!isDraft) {
       this.site.status = siteStatusEnum.ACTIVE;
     }
-
-    this.publisherService.saveSite(this.site).subscribe(
-      () => {
-        this.store.dispatch(new publisherActions.AddSiteToSitesSuccess(this.site));
-        this.store.dispatch(new publisherActions.ClearLastEditedSite({}));
-        this.router.navigate(['/publisher', 'dashboard']);
-      },
-      (err) => {
-        this.canSubmit = true;
-        this.showErrorInformation(err);
-      }
-    );
-  }
-
-  updateSite(): void {
-    this.canSubmit = false;
-    const siteId = this.site.id;
-    this.store.dispatch(new publisherActions.UpdateSiteFiltering(this.site));
-    this.navigateToSiteDetails(siteId);
-  }
-
-  showErrorInformation(err: { status: number, error: { message: string } }): void {
-    if (err.status === 500) return;
-    this.dialog.open(ErrorResponseDialogComponent, {
-      data: {
-        title: 'Ups! Something went wrong...',
-        message: `We weren\'t able to save your site due to this error: ${err.error.message} \n Please try again later.`,
-      }
-    });
-  }
-
-  navigateToSiteDetails(id: number): void {
-    this.router.navigate(['/publisher', 'site', id]);
+    this.store.dispatch(new AddSiteToSites(this.site));
   }
 }

--- a/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
+++ b/src/app/publisher/edit-site/edit-site-summary/edit-site-summary.component.ts
@@ -8,7 +8,7 @@ import { Site } from 'models/site.model';
 import { siteStatusEnum } from 'models/enum/site.enum';
 import { PublisherService } from 'publisher/publisher.service';
 import { AssetHelpersService } from 'common/asset-helpers.service';
-import {AddSiteToSites} from 'store/publisher/publisher.actions';
+import { AddSiteToSites } from 'store/publisher/publisher.actions';
 import { HandleSubscription } from 'common/handle-subscription';
 import { TargetingOption } from 'models/targeting-option.model';
 import { cloneDeep } from 'common/utilities/helpers';
@@ -38,7 +38,7 @@ export class EditSiteSummaryComponent extends HandleSubscription implements OnIn
       .first()
       .subscribe((lastEditedSite: Site) => {
         this.filteringOptions = cloneDeep(this.route.parent.snapshot.data.filteringOptions);
-        this.site =  lastEditedSite;
+        this.site = lastEditedSite;
       });
 
     this.subscriptions.push(lastSiteSubscription);

--- a/src/app/publisher/edit-site/edit-site.component.ts
+++ b/src/app/publisher/edit-site/edit-site.component.ts
@@ -9,6 +9,7 @@ import * as publisherActions from 'store/publisher/publisher.actions';
 import { parseTargetingOptionsToArray } from 'common/components/targeting/targeting.helpers';
 import { Site } from 'models/site.model';
 import { AssetTargeting } from 'models/targeting-option.model';
+import { HandleSubscription } from "common/handle-subscription";
 
 @Component({
   selector: 'app-edit-site',
@@ -16,7 +17,7 @@ import { AssetTargeting } from 'models/targeting-option.model';
   styleUrls: ['./edit-site.component.scss'],
   animations: [fadeAnimation]
 })
-export class EditSiteComponent implements OnInit, OnDestroy {
+export class EditSiteComponent extends HandleSubscription implements OnInit, OnDestroy {
   getRouterOutletState = (outlet) => outlet.isActivated ? outlet.activatedRoute : '';
   isEditMode: boolean;
 
@@ -25,11 +26,12 @@ export class EditSiteComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private router: Router,
   ) {
+    super();
   }
 
   ngOnInit() {
     this.isEditMode = !!this.router.url.match('/edit-site/');
-    this.store.select('state', 'publisher', 'lastEditedSite')
+    const lastEditedSiteSubscription = this.store.select('state', 'publisher', 'lastEditedSite')
       .take(1)
       .subscribe((lastEditedSite: Site) => {
         const requires = lastEditedSite.filtering.requires || [];
@@ -52,6 +54,7 @@ export class EditSiteComponent implements OnInit, OnDestroy {
           )
         }
       });
+    this.subscriptions.push(lastEditedSiteSubscription);
   }
 
   ngOnDestroy() {

--- a/src/app/publisher/publisher.service.ts
+++ b/src/app/publisher/publisher.service.ts
@@ -61,13 +61,6 @@ export class PublisherService {
   }
 
   updateSiteData(id: number, site: Site): Observable<Site> {
-    if (site.filteringArray) {
-      const filteringObject = parseTargetingForBackend(site.filteringArray);
-      site = {
-        ...site,
-        filtering: filteringObject
-      };
-    }
     const {filteringArray, ...reducedSite} = site;
 
     return this.http.patch<Site>(`${environment.apiUrl}/sites/${id}`, {site: reducedSite});

--- a/src/app/publisher/site-list/site-list-item/site-list-item.component.ts
+++ b/src/app/publisher/site-list/site-list-item/site-list-item.component.ts
@@ -6,6 +6,7 @@ import { enumToArray } from "common/utilities/helpers";
 import { MatDialog } from "@angular/material";
 import { UpdateSiteStatus } from "store/publisher/publisher.actions";
 import { AppState } from "models/app-state.model";
+import { Site } from "models/site.model";
 
 @Component({
   selector: 'app-site-list-item',
@@ -13,7 +14,7 @@ import { AppState } from "models/app-state.model";
   styleUrls: ['./site-list-item.component.scss']
 })
 export class SiteListItemComponent implements OnInit {
-  @Input() site;
+  @Input() site: Site;
   siteStatusEnum = siteStatusEnum;
   siteStatusEnumArray = enumToArray(siteStatusEnum);
   currentSiteStatus: string;
@@ -24,7 +25,7 @@ export class SiteListItemComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.currentSiteStatus = siteStatusEnum[this.site.status].toLowerCase();
+    this.currentSiteStatus = typeof this.site.status === 'number' && this.siteStatusEnum[this.site.status].toLowerCase();
   }
 
   onSiteStatusChange(status) {

--- a/src/app/store/advertiser/advertiser.actions.ts
+++ b/src/app/store/advertiser/advertiser.actions.ts
@@ -9,6 +9,7 @@ export const SAVE_CAMPAIGN_BASIC_INFORMATION = 'Basic Campaign Information saved
 export const SAVE_CAMPAIGN_TARGETING = 'Campaing targeting information saved';
 export const SAVE_CAMPAIGN_ADS = 'Campaing ads saved';
 
+
 export const ADD_CAMPAIGN_TO_CAMPAIGNS = 'Campaign added to user campaigns';
 export const ADD_CAMPAIGN_TO_CAMPAIGNS_SUCCESS = 'Campaign added to user campaigns success';
 export const ADD_CAMPAIGN_TO_CAMPAIGNS_FAILURE = 'Campaign added to user campaigns failure';

--- a/src/app/store/advertiser/advertiser.reducers.ts
+++ b/src/app/store/advertiser/advertiser.reducers.ts
@@ -1,7 +1,7 @@
 import * as advertiserActions from './advertiser.actions';
 import * as authActions from '../auth/auth.actions';
-import {AdvertiserState} from 'models/app-state.model';
-import {campaignInitialState, campaignsTotalsInitialState} from 'models/initial-state/campaign';
+import { AdvertiserState } from 'models/app-state.model';
+import { campaignInitialState, campaignsTotalsInitialState } from 'models/initial-state/campaign';
 
 const initialState: AdvertiserState = {
   lastEditedCampaign: campaignInitialState,
@@ -73,7 +73,7 @@ export function advertiserReducers(state = initialState, action: advertiserActio
     case advertiserActions.SAVE_CAMPAIGN_TARGETING:
       return {
         ...state,
-        lastEditedCampaign: Object.assign({}, state.lastEditedCampaign, {targetingArray: action.payload})
+        lastEditedCampaign: {...state.lastEditedCampaign, targetingArray: action.payload}
       };
     case advertiserActions.SAVE_CAMPAIGN_ADS:
       return {

--- a/src/app/store/common/common.effects.ts
+++ b/src/app/store/common/common.effects.ts
@@ -1,15 +1,20 @@
 import { Injectable } from '@angular/core';
-import { Actions, Effect } from '@ngrx/effects';
+import { Actions, Effect, toPayload } from '@ngrx/effects';
 import 'rxjs/add/operator/switchMap';
 
 import { CommonService } from 'common/common.service';
 import * as commonActions from './common.actions';
+import * as advertiserActions from "store/advertiser/advertiser.actions";
+import * as publisherActions from "store/publisher/publisher.actions";
+import { ErrorResponseDialogComponent } from "common/dialog/error-response-dialog/error-response-dialog.component";
+import { MatDialog } from "@angular/material";
 
 @Injectable()
 export class CommonEffects {
   constructor(
     private actions$: Actions,
-    private service: CommonService
+    private service: CommonService,
+    private dialog: MatDialog,
   ) {
   }
 
@@ -18,4 +23,22 @@ export class CommonEffects {
     .ofType(commonActions.LOAD_NOTIFICATIONS)
     .switchMap(() => this.service.getNotifications())
     .map(notifications => new commonActions.LoadNotificationsSuccess(notifications));
+
+  @Effect({dispatch: false})
+  handleErrors = this.actions$
+    .ofType(
+      advertiserActions.UPDATE_CAMPAIGN_STATUS_FAILURE,
+      advertiserActions.DELETE_CAMPAIGN_FAILURE,
+      advertiserActions.DELETE_CAMPAIGN_FAILURE,
+      publisherActions.ADD_SITE_TO_SITES_FAILURE
+    )
+    .map(toPayload)
+    .do(payload => {
+      this.dialog.open(ErrorResponseDialogComponent, {
+        data: {
+          title: `Error occurred`,
+          message: `${payload}`,
+        }
+      });
+    });
 }

--- a/src/app/store/publisher/publisher.actions.ts
+++ b/src/app/store/publisher/publisher.actions.ts
@@ -33,8 +33,10 @@ export const SET_LAST_EDITED_SITE = 'Last edited site set';
 export const SAVE_LAST_EDITED_SITE = 'Basic site informations saved';
 export const SAVE_LAST_EDITED_SITE_FILTERING = 'Site filtering saved';
 export const SAVE_LAST_EDITED_SITE_AD_UNITS = 'Site ad units saved';
-export const ADD_SITE_TO_SITES = 'Site added to user sites';
-export const ADD_SITE_TO_SITES_SUCCESS = 'Site added to user sites success';
+
+export const ADD_SITE_TO_SITES = 'Save site';
+export const ADD_SITE_TO_SITES_SUCCESS = 'Save site success';
+export const ADD_SITE_TO_SITES_FAILURE = 'Save site failure';
 
 export const UPDATE_SITE = 'Site update';
 export const UPDATE_SITE_SUCCESS = 'Site update success';
@@ -178,6 +180,13 @@ export class AddSiteToSitesSuccess implements Action {
   readonly type = ADD_SITE_TO_SITES_SUCCESS;
 
   constructor(public payload: Site) {
+  }
+}
+
+export class AddSiteToSitesFailure implements Action {
+  readonly type = ADD_SITE_TO_SITES_FAILURE;
+
+  constructor(public payload?: string) {
   }
 }
 

--- a/src/app/store/publisher/publisher.effects.ts
+++ b/src/app/store/publisher/publisher.effects.ts
@@ -1,17 +1,18 @@
-import {Injectable} from '@angular/core';
-import {Actions, Effect, toPayload} from '@ngrx/effects';
-import {Router} from "@angular/router";
+import { Injectable } from '@angular/core';
+import { Actions, Effect, toPayload } from '@ngrx/effects';
+import { Router } from "@angular/router";
 
 import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/catch';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/switchMap';
-import {PublisherService} from 'publisher/publisher.service';
+import { PublisherService } from 'publisher/publisher.service';
 import * as publisherActions from './publisher.actions';
-import {prepareTargetingChoices} from "common/components/targeting/targeting.helpers";
-import {Observable} from "rxjs";
+import { prepareTargetingChoices } from "common/components/targeting/targeting.helpers";
+import { Observable } from "rxjs";
 import "rxjs/add/operator/takeLast";
 import * as moment from "moment";
+import { HTTP_INTERNAL_SERVER_ERROR } from "common/utilities/codes";
 
 @Injectable()
 export class PublisherEffects {
@@ -77,8 +78,24 @@ export class PublisherEffects {
   addSiteToSites = this.actions$
     .ofType(publisherActions.ADD_SITE_TO_SITES)
     .map(toPayload)
-    .switchMap((payload) => this.service.saveSite(payload))
-    .map((site) => new publisherActions.AddSiteToSitesSuccess(site));
+    .switchMap((payload) => this.service.saveSite(payload)
+      .switchMap((site) => {
+        this.router.navigate(['/publisher', 'dashboard']);
+
+        return [
+          new publisherActions.AddSiteToSitesSuccess(site),
+          new publisherActions.ClearLastEditedSite()
+        ]
+      })
+      .catch(err => {
+        if (err !== HTTP_INTERNAL_SERVER_ERROR) {
+          return Observable.of(new publisherActions.AddSiteToSitesFailure(
+            `We weren\'t able to save your site due to this error: ${err.error.message} \n
+            Please try again later.`
+          ))
+        }
+      })
+    );
 
   @Effect()
   getLanguageList = this.actions$
@@ -97,7 +114,10 @@ export class PublisherEffects {
 
   @Effect()
   updateSite = this.actions$
-    .ofType(publisherActions.UPDATE_SITE)
+    .ofType(
+      publisherActions.UPDATE_SITE,
+      publisherActions.UPDATE_SITE_FILTERING
+    )
     .map(toPayload)
     .switchMap(payload => this.service.updateSiteData(payload.id, payload)
       .switchMap(() => {
@@ -118,20 +138,4 @@ export class PublisherEffects {
       .map(() => new publisherActions.UpdateSiteStatusSuccess(payload))
       .catch(() => Observable.of(new publisherActions.UpdateSiteStatusFailure()))
     );
-
-  @Effect()
-  updateSiteFiltering = this.actions$
-    .ofType(publisherActions.UPDATE_SITE_FILTERING)
-    .map(toPayload)
-    .switchMap(payload => this.service.updateSiteFiltering(payload.id, payload)
-      .switchMap(() => {
-        this.router.navigate(['/publisher', 'site', payload.id]);
-        return [
-          new publisherActions.UpdateSiteFilteringSuccess(payload),
-          new publisherActions.ClearLastEditedSite(),
-        ]
-      })
-      .catch(() => Observable.of(new publisherActions.UpdateSiteFilteringFailure()))
-    )
-
 }

--- a/src/assets/images/document-png--blue.svg
+++ b/src/assets/images/document-png--blue.svg
@@ -9,7 +9,7 @@
         </g>
         <path fill="#DEEEF9" stroke="#55A8FD" stroke-linecap="square" stroke-width="2" d="M24 3v7h7"/>
         <rect width="27" height="15" x="11" y="20" fill="#55A8FD" rx="2"/>
-        <text fill="#FFF" font-family="AvenirNext-Bold, Avenir Next" font-size="9" font-weight="bold">
+        <text fill="#FFF" font-family="Lato-Bold,  Next" font-size="9" font-weight="bold">
             <tspan x="15" y="31">PNG</tspan>
         </text>
     </g>

--- a/src/styles/_common.scss
+++ b/src/styles/_common.scss
@@ -329,6 +329,7 @@ router-outlet ~ * {
   @include font(14, semi);
   text-transform: uppercase;
   width: 100%;
+  max-width: 150px;
   border: none;
   padding: 4px 8px;
   margin: 0;

--- a/src/styles/_fonts.scss
+++ b/src/styles/_fonts.scss
@@ -5,7 +5,7 @@ $fonts: (
   medium: 'Lato-Regular',
   normal: 'Lato-Regular',
   semi: 'Lato-Bold',
-  copy: 'AvenirNext-Regular'
+  copy: 'Lato-Regular'
 );
 
 @mixin font-face($font-name) {

--- a/src/styles/_material-override.scss
+++ b/src/styles/_material-override.scss
@@ -127,7 +127,7 @@ mat-chip:not(.mat-basic-chip) {
 
 .mat-checkbox-label {
   color: pal(navy, light);
-  font-family: "AvenirNext-Regular", sans-serif;
+  font-family: "Lato-Regular", sans-serif;
   font-size: 15px;
   line-height: 1;
 }


### PR DESCRIPTION
Changes in this pr: 

- Refactored main save site and campaign functions - use redux actions instead of direct service calls
- Show warning when the campaign couldn't be automatically activated 
-  Implemented handle subscriptions component where needed, also fixed manual repetitive unsubscribe functions onDestroy
-  Minor visual corrections for campaign list - status cell
