### PR TITLE
Fix docker-compose - after .env variables changes

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -8,6 +8,6 @@ services:
         SYSTEM_USER_ID: ${SYSTEM_USER_ID}
         SYSTEM_USER_NAME: ${SYSTEM_USER_NAME}
     ports:
-    - "${WEBSERVER_PORT}:9000"
-    command: ['serve','--environment','${APP_ENV}','--host','0.0.0.0','--port','9000','--public-host','${WEBSERVER_HOST}']
+    - "${APP_PORT}:9000"
+    command: ['serve','--environment','${APP_ENV}','--host','0.0.0.0','--port','9000','--public-host','${APP_HOST}']
     user: ${SYSTEM_USER_ID}


### PR DESCRIPTION
docker-compose should use the same variables as .env